### PR TITLE
Fix build using CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ idf_component_register(
 			SRCS "revk.c" "jo.c" "lwmqtt.c"
 			INCLUDE_DIRS "include"
 			REQUIRES nvs_flash app_update esp_http_client esp-tls
-			EMBED_FILES "../../build/partition_table/partition-table-unsigned.bin"
+			EMBED_FILES "../../build/partition_table/partition-table.bin"
 )
 add_definitions(-DBUILD_ESP32_USING_CMAKE)
-set_property(SOURCE "../../build/partition_table/partition-table-unsigned.bin" PROPERTY GENERATED 1)
+set_property(SOURCE "../../build/partition_table/partition-table.bin" PROPERTY GENERATED 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,8 @@
 idf_component_register(
-			SRCS "revk.c"
+			SRCS "revk.c" "jo.c" "lwmqtt.c"
 			INCLUDE_DIRS "include"
+			REQUIRES nvs_flash app_update esp_http_client esp-tls
+			EMBED_FILES "../../build/partition_table/partition-table-unsigned.bin"
 )
+add_definitions(-DBUILD_ESP32_USING_CMAKE)
+set_property(SOURCE "../../build/partition_table/partition-table-unsigned.bin" PROPERTY GENERATED 1)

--- a/revk.c
+++ b/revk.c
@@ -1340,8 +1340,8 @@ void revk_boot(app_callback_t * app_callback_cb)
    /* Watchdog */
 #ifdef	CONFIG_REVK_PARTITION_CHECK
 #ifdef  BUILD_ESP32_USING_CMAKE
-   extern const uint8_t part_start[] asm("_binary_partition_table_unsigned_bin_start");
-   extern const uint8_t part_end[] asm("_binary_partition_table_unsigned_bin_start");
+   extern const uint8_t part_start[] asm("_binary_partition_table_bin_start");
+   extern const uint8_t part_end[] asm("_binary_partition_table_bin_start");
 #else
    extern const uint8_t part_start[] asm("_binary_partitions_4m_bin_start");
    extern const uint8_t part_end[] asm("_binary_partitions_4m_bin_end");

--- a/revk.c
+++ b/revk.c
@@ -1339,8 +1339,13 @@ void revk_boot(app_callback_t * app_callback_cb)
 #endif
    /* Watchdog */
 #ifdef	CONFIG_REVK_PARTITION_CHECK
+#ifdef  BUILD_ESP32_USING_CMAKE
+   extern const uint8_t part_start[] asm("_binary_partition_table_unsigned_bin_start");
+   extern const uint8_t part_end[] asm("_binary_partition_table_unsigned_bin_start");
+#else
    extern const uint8_t part_start[] asm("_binary_partitions_4m_bin_start");
    extern const uint8_t part_end[] asm("_binary_partitions_4m_bin_end");
+#endif
    /* Check and update partition table - expects some code to stay where it can run, i.e.0x10000, but may clear all settings */
    if ((part_end - part_start) > SPI_FLASH_SEC_SIZE)
    {


### PR DESCRIPTION
Part of a collection of updates to allow the ESP32 code to build via CMake. [2/3]

CMake builds the partition bin file at a different location hence the tweak to revk.c to cater for it.