### PR TITLE
Fix build without mdns component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(RECS nvs_flash app_update esp_http_client esp-tls esp_http_server spi_flash 
 
 if(EXISTS "../managed_components/espressif__mdns")
 	set(RECS ${RECS} mdns)
+	add_definitions(-DHAVE_MDNS)
 endif()
 
 idf_component_register(

--- a/revk.c
+++ b/revk.c
@@ -30,6 +30,13 @@ static const char __attribute__((unused)) * TAG = "RevK";
 #include <esp_mesh.h>
 #include "freertos/semphr.h"
 #endif
+// CONFIG_* have been picked up at this point
+#ifndef HAVE_MDNS
+#ifdef CONFIG_MDNS_MAX_INTERFACES
+#warning CONFIG_MDNS_MAX_INTERFACES is set but espressif__mdns is not present!
+#undef CONFIG_MDNS_MAX_INTERFACES
+#endif
+#endif
 #ifdef  CONFIG_MDNS_MAX_INTERFACES
 #include "mdns.h"
 #endif


### PR DESCRIPTION
If managed_components/espressif__mdns is not present, mdns component will not be added, however the code still expects it and tries to include mdns.h. Fix the build, but keep a warning to inform the developer.