### PR TITLE
Fix OTA on 8266

### DIFF
--- a/buildsuffix
+++ b/buildsuffix
@@ -13,10 +13,11 @@ endif
 # ensure date/time set
 grep -q CONFIG_IDF_TARGET_ESP8266=y "$SDKCONFIG"
 if (! $status) then
+    # 8266 variants: -8266 -8266-4M
 	setenv  SUFFIX  "$SUFFIX-8266"
+	grep -q partitions_4m "$SDKCONFIG"
+	if(! $status) 	setenv	SUFFIX	"$SUFFIX-4M"
 	touch "${IDF_PATH}/components/app_update/esp_app_desc.c"
-else
-	touch "${IDF_PATH}/components/esp_app_format/esp_app_desc.c"
 endif
 
 grep -q CONFIG_IDF_TARGET_ESP32=y "$SDKCONFIG"
@@ -41,6 +42,7 @@ if(! $status) 	then
 		grep -q CONFIG_REVK_PICO=y "$SDKCONFIG"
 		if(! $status) 	setenv	SUFFIX	"$SUFFIX-PICO"
 	endif
+	touch "${IDF_PATH}/components/esp_app_format/esp_app_desc.c"
 endif
 
 grep -q CONFIG_IDF_TARGET_ESP32S2=y "$SDKCONFIG"

--- a/partitions_4m-8266.csv
+++ b/partitions_4m-8266.csv
@@ -1,0 +1,11 @@
+# Espressif ESP32 Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+RevK,     data, nvs,     0x009000,0x004000,
+otadata,  data, ota,     0x00d000,0x002000,
+phy_init, data, phy,     0x00f000,0x001000,
+ota_0,	  0,    ota_0,   0x010000,0x1e0000,
+esp_secure_cert,  0x3F, ,0x1f0000,0x002000, encrypted
+fctry,    data, nvs,     0x200000,0x006000
+ota_1,	  0,    ota_1,   0x210000,0x1e0000,
+nvs,      data, nvs,     0x3F0000,0x00f000,
+nvs_key,  data, nvs_keys,0x3FF000,0x001000,

--- a/partitions_8m-8266.csv
+++ b/partitions_8m-8266.csv
@@ -1,0 +1,11 @@
+# Espressif ESP32 Partition Table
+# Name,   Type, SubType, Offset,  Size, Flags
+RevK,     data, nvs,     0x009000,0x004000,
+otadata,  data, ota,     0x00d000,0x002000,
+phy_init, data, phy,     0x00f000,0x001000,
+ota_0,	  0,    ota_0,   0x010000,0x1e0000,
+esp_secure_cert,  0x3F, ,0x1f0000,0x002000, encrypted
+fctry,    data, nvs,     0x200000,0x006000
+ota_1,	  0,    ota_1,   0x210000,0x1e0000,
+nvs,      data, nvs,     0x3F0000,0x00f000,
+nvs_key,  data, nvs_keys,0x3FF000,0x001000,

--- a/setbuildsuffix
+++ b/setbuildsuffix
@@ -34,6 +34,18 @@ else
 	endif
 endif
 
+if("$BUILDSUFFIX" =~ *-8266*) then
+    if("$BUILDSUFFIX" =~ *-4M*) then
+		set add=($add CONFIG_ESPTOOLPY_FLASHSIZE_4MB CONFIG_PARTITION_TABLE_CUSTOM)
+		set rem=($rem CONFIG_ESPTOOLPY_FLASHSIZE_8MB)
+		set part="components/ESP32-RevK/partitions_4m-8266.csv"
+	else
+		set add=($add CONFIG_ESPTOOLPY_FLASHSIZE_8MB CONFIG_PARTITION_TABLE_CUSTOM)
+		set rem=($rem CONFIG_ESPTOOLPY_FLASHSIZE_4MB)
+		set part="components/ESP32-RevK/partitions_8m-8266.csv"
+	endif
+endif
+
 if("$BUILDSUFFIX" =~ *-S1*) then
 	grep -q CONFIG_IDF_TARGET_ESP32=y "$SDKCONFIG"
 	if($status) then


### PR DESCRIPTION
ESP8266 requires app partition addresses to only differ by one bit. If this requirement isn't met, the chip will unrecoverably crash after the update; reflashing over the wire will be needed.

The information found here: https://www.esp8266.com/viewtopic.php?p=89807