### PR TITLE
revk: Introduce revk_num_web_handlers()

### DIFF
--- a/include/revk.h
+++ b/include/revk.h
@@ -154,6 +154,7 @@ void revk_mesh_send_json (const mac_t mac, jo_t * jp);
 #endif
 void revk_blink (uint8_t on, uint8_t off, const char *colours); // Set LED blink rate and colour sequence for on state (for RGB LED)
 
+uint16_t revk_num_web_handlers (void);  // Number of handlers used by revk_web_settings_add()
 esp_err_t revk_web_settings_add (httpd_handle_t webserver);     // Add URLs
 esp_err_t revk_web_settings_remove (httpd_handle_t webserver);  // Remove URLs
 esp_err_t revk_web_settings (httpd_req_t * req);        // Call for web config for SSID/password/mqtt (GET/POST) - needs 4 URLS

--- a/revk.c
+++ b/revk.c
@@ -2255,6 +2255,15 @@ revk_restart (const char *reason, int delay)
 #endif
 #endif
 
+// This function returns numbers of handlers, used by revk_web_settings_add() below
+// Provides a convenient way for the app to configure max_uri_handlers
+// !!! Update when adding/removing handlers below !!!
+uint16_t
+revk_num_web_handlers (void)
+{
+   return 4;
+}
+
 esp_err_t
 revk_web_settings_add (httpd_handle_t webserver)
 {


### PR DESCRIPTION
Introduce a function, which returns number of handlers, used by revk_web_settings_add(). It it useful when integrating revk settings into an application's own web server. Provides a convenient way to keep max_uri_handlers up to date and avoiding de-sync.