### PR TITLE
revk_settings: Enable build under Win32

### DIFF
--- a/revk_settings.c
+++ b/revk_settings.c
@@ -7,7 +7,41 @@
 #include <sys/time.h>
 #include <stdlib.h>
 #include <ctype.h>
+
+#ifndef _WIN32
 #include <err.h>
+#else
+#define err(n, fmt, ...) fprintf(stderr, fmt "\n", __VA_ARGS__);
+#define errx(n, ...) fprintf(stderr, __VA_ARGS__)
+
+// Very crude replacement, only enough for us here
+static int
+getline(char **lineptr, size_t *n, FILE *stream)
+{
+    static char line_buffer[1024];
+
+	if (!fgets(line_buffer, sizeof(line_buffer), stream))
+		return -1;
+
+	*lineptr = line_buffer;
+	return 1;
+}
+
+static char *
+strndup(const char *str, size_t len)
+{
+	int l = strlen(str);
+	char *dest;
+	
+	if (len < l)
+		l = len;
+	dest = malloc(l + 1);
+	memcpy(dest, str, len);
+	dest[l] = 0;
+	return dest;
+}
+
+#endif
 
 typedef struct def_s def_t;
 struct def_s


### PR DESCRIPTION
Now builds successfully using MinGW; this allows to execute "make settings.h" before proceeding with "idf.py build" in ESP32 environment

Fixes https://github.com/revk/ESP32-RevK/issues/24 , at least partly