### PR TITLE
revk: Fix build error on 8266

### DIFF
--- a/revk.c
+++ b/revk.c
@@ -1936,9 +1936,11 @@ task (void *pvParameters)
 #endif
             {
 #ifdef	CONFIG_REVK_MQTT
-               sprintf (mq, " MQTT %u", lwmqtt_connected (mqtt_client[0]));
+               // on ESP8266 uint32_t is just unsigned int, need to explicitly
+               // cast to unsigne long to avoid compiler errors
+               sprintf (mq, " MQTT %lu", (unsigned long)lwmqtt_connected (mqtt_client[0]));
 #if	    CONFIG_REVK_MQTT_CLIENTS>1
-               sprintf (mq + strlen (mq), "/%u", lwmqtt_connected (mqtt_client[1]));
+               sprintf (mq + strlen (mq), "/%lu", (unsigned long)lwmqtt_connected (mqtt_client[1]));
 #endif
 #endif
             }

--- a/revk.c
+++ b/revk.c
@@ -1936,9 +1936,9 @@ task (void *pvParameters)
 #endif
             {
 #ifdef	CONFIG_REVK_MQTT
-               sprintf (mq, " MQTT %lu", lwmqtt_connected (mqtt_client[0]));
+               sprintf (mq, " MQTT %u", lwmqtt_connected (mqtt_client[0]));
 #if	    CONFIG_REVK_MQTT_CLIENTS>1
-               sprintf (mq + strlen (mq), "/%lu", lwmqtt_connected (mqtt_client[1]));
+               sprintf (mq + strlen (mq), "/%u", lwmqtt_connected (mqtt_client[1]));
 #endif
 #endif
             }


### PR DESCRIPTION
error: format '%lu' expects argument of type 'long unsigned int', but argument 3 has type 'uint32_t' {aka 'unsi
gned int'} [-Werror=format=]
