### PR TITLE
revk: Fix NVS if flashing a non-empty ESP32

### DIFF
--- a/revk.c
+++ b/revk.c
@@ -1,4 +1,4 @@
-// Main control code, working with WiFi, MQTT, and managing settings and OTA Copyright Â ©2019 Adrian Kennard Andrews & Arnold Ltd
+// Main control code, working with WiFi, MQTT, and managing settings and OTA Copyright ï¿½ ï¿½2019 Adrian Kennard Andrews & Arnold Ltd
 static const char __attribute__((unused)) * TAG = "RevK";
 
 //#define       SETTING_DEBUG
@@ -2432,8 +2432,17 @@ revk_boot (app_callback_t * app_callback_cb)
 #endif
    ESP_LOGI (TAG, "nvs_flash_init");
    nvs_flash_init ();
+
+   // Check if NVS will produce and error on startup and format it if needed
    ESP_LOGI (TAG, "nvs_flash_init_partition");
-   nvs_flash_init_partition (TAG);
+   esp_err_t ret_code = nvs_flash_init_partition (TAG);
+   if (ret_code == ESP_ERR_NVS_NO_FREE_PAGES || ret_code == ESP_ERR_NVS_NEW_VERSION_FOUND)
+   {
+      ESP_LOGE (TAG, "nvs_flash_init_partition failed, erasing nvs_flash");
+      nvs_flash_erase ();
+      nvs_flash_init_partition (TAG);
+   }
+   
    ESP_LOGI (TAG, "nvs_open_from_partition");
    const esp_app_desc_t *app = esp_app_get_description ();
 #ifndef	CONFIG_REVK_OLD_SETTINGS

--- a/revk.c
+++ b/revk.c
@@ -1,4 +1,4 @@
-// Main control code, working with WiFi, MQTT, and managing settings and OTA Copyright � �2019 Adrian Kennard Andrews & Arnold Ltd
+// Main control code, working with WiFi, MQTT, and managing settings and OTA Copyright Â ©2019 Adrian Kennard Andrews & Arnold Ltd
 static const char __attribute__((unused)) * TAG = "RevK";
 
 //#define       SETTING_DEBUG

--- a/revk.c
+++ b/revk.c
@@ -2439,7 +2439,7 @@ revk_boot (app_callback_t * app_callback_cb)
    if (ret_code == ESP_ERR_NVS_NO_FREE_PAGES || ret_code == ESP_ERR_NVS_NEW_VERSION_FOUND)
    {
       ESP_LOGE (TAG, "nvs_flash_init_partition failed, erasing nvs_flash");
-      nvs_flash_erase ();
+      nvs_flash_erase_partition (TAG);
       nvs_flash_init_partition (TAG);
    }
    


### PR DESCRIPTION
While trying to install the [Faikin](https://github.com/revk/ESP32-Faikin) in a DIY already flashed ESP32-S3, I wasn't able to save the settings from the webpage

I noticed that erasing the flash with `esptool.py erase_flash` and reflashing the same ESP32 again with the same cmdline _`esptool.py -p /dev/ttyUSB0 write_flash 0x0 Faikin-S3-MINI-N8-bootloader.bin 0x8000 partition-table.bin 0xd000 ota_data_initial.bin 0x10000 Faikin-S3-MINI-N8.bin`_, it works, leading me to believe that something is wrong with the NVS init routine. 

What I've done here is a walkaround to verify if the `nvs_flash_init_partition()` is valid; if not, format and create the partition, possibly fixing that issue.

Before this fix (the `Cannot store ...` msg happens for all the settings): 
![image](https://github.com/user-attachments/assets/7b8acb9c-639e-435d-ba03-ab0fcde20e49)

After the fix (success, no error message):
![image](https://github.com/user-attachments/assets/b8ccf7c2-31ba-4751-a59b-cff8a1c2565f)

I suggest doing the same for the ESP32-BLE-Env repo.

Edit: In addition to that, I compiled the Faikin source code with and without the fix, in a way to verify if everything was working, may need some additional tests on your guys side just as a sanity check